### PR TITLE
Add 'socket_type' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,25 @@ Process.wait(pid)
 # Received message: serialized by Marshal
 ```
 
+### Socket
+
+#### Types
+
+A channel can be created with one of three sockets types:
+
+* `Socket::SOCK_DGRAM`
+* `Socket::SOCK_STREAM`
+* `Socket::SOCK_SEQPACKET`
+
+The default is `Socket::SOCK_DGRAM` because its default settings
+provide the most buffer space. The socket type can be specified with
+the `socket_type` keyword argument:
+
+```ruby
+require "xchan"
+ch = xchan(:marshal, socket_type: Socket::SOCK_STREAM)
+```
+
 ### Read operations
 
 #### `#recv`
@@ -116,7 +135,7 @@ example performs a write that will block when the send buffer becomes full:
 ```ruby
 require "xchan"
 
-ch = xchan
+ch = xchan(:marshal, socket_type: Socket::SOCK_STREAM)
 500.times { ch.send("a" * 500) }
 ```
 

--- a/lib/xchan/mixin.rb
+++ b/lib/xchan/mixin.rb
@@ -1,17 +1,17 @@
+##
+# A module that is included into Ruby's {Object} class.
+module Chan::Mixin
   ##
-  # A module that is included into Ruby's {Object} class.
-  module Chan::Mixin
-    ##
-    # @example
-    #   ch = xchan
-    #   ch.send([1,2,3])
-    #   ch.recv.pop # => 3
-    #   ch.close
-    #
-    # @param serializer (see Chan::UNIXSocket#initialize)
-    #
-    # @return (see Chan::UNIXSocket#initialize)
-    def xchan(serializer = :marshal)
-      Chan::UNIXSocket.new(serializer)
-    end
+  # @example
+  #   ch = xchan
+  #   ch.send([1,2,3])
+  #   ch.recv.pop # => 3
+  #   ch.close
+  #
+  # @param serializer (see Chan::UNIXSocket#initialize)
+  # @param socket_type (see Chan::UNIXSocket#initialize)
+  # @return (see Chan::UNIXSocket#initialize)
+  def xchan(serializer = :marshal, **kw_args)
+    Chan::UNIXSocket.new(serializer, **kw_args)
   end
+end

--- a/lib/xchan/unix_socket.rb
+++ b/lib/xchan/unix_socket.rb
@@ -18,11 +18,14 @@ class Chan::UNIXSocket
   # @param [Symbol, <#dump, #load>] serializer
   #  A serializer.
   #
+  # @param [Integer] socket_type
+  #  A socket type (ie Socket::SOCK_STREAM).
+  #
   # @return [Chan::UNIXSocket]
   #  Returns an instance of {Chan::UNIXSocket Chan::UNIXSocket}.
-  def initialize(serializer)
+  def initialize(serializer, socket_type: Socket::SOCK_DGRAM)
     @serializer = Chan::SERIALIZERS[serializer]&.call || serializer
-    @r, @w = ::UNIXSocket.pair(:STREAM)
+    @r, @w = ::UNIXSocket.pair(socket_type)
     @bytes = Chan::ByteArray.new
     @lock = LockFile.new(new_temp_file)
   end

--- a/share/xchan.rb/write_operations/2_nonblocking_write.rb
+++ b/share/xchan.rb/write_operations/2_nonblocking_write.rb
@@ -14,5 +14,5 @@ rescue Chan::WaitLockable
   retry
 end
 
-ch = xchan
+ch = xchan(:marshal, socket_type: Socket::SOCK_STREAM)
 170.times { send_nonblock(ch, "a" * 500) }


### PR DESCRIPTION
The optional keyword argument 'socket_type' can specify 
what type of socket a channel should use. 
The default  is `Socket::SOCK_DGRAM`